### PR TITLE
Use event type when determining next block to process

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -16,14 +16,14 @@ module.exports = {
       url: process.env.PINO_ELASTIC_SEARCH_URL || null,
     },
   },
-  v1: {
-    genesisBlock: 4145578,
-  },
-  v2: {
-    genesisBlock: 8140780,
-  },
-  v3: {
-    genesisBlock: 8952139,
+  startBlock: {
+    fill: {
+      v2: 8140780,
+      v3: 8952139,
+    },
+    logFill: {
+      v1: 4145578,
+    },
   },
   web3: {
     endpoint: process.env.WEB3_ENDPOINT,

--- a/packages/core/src/events/get-config-for-event-type.js
+++ b/packages/core/src/events/get-config-for-event-type.js
@@ -1,0 +1,20 @@
+const _ = require('lodash');
+const { config } = require('@0x-event-extractor/shared');
+
+const getConfigForEventType = (eventType, protocolVersion) => {
+  const camelEventType = _.camelCase(eventType);
+  const startBlockKey = `startBlock.${camelEventType}.v${protocolVersion}`;
+  const startBlock = config.get(startBlockKey);
+  const maxChunkSize = config.get('maxChunkSize');
+  const minConfirmations = config.get('minConfirmations');
+
+  if (startBlock === undefined) {
+    throw new Error(
+      `Start block config not found for v${protocolVersion} ${eventType} events`,
+    );
+  }
+
+  return { startBlock, maxChunkSize, minConfirmations };
+};
+
+module.exports = getConfigForEventType;

--- a/packages/core/src/events/get-last-processed-block.js
+++ b/packages/core/src/events/get-last-processed-block.js
@@ -1,13 +1,9 @@
 const BlockRange = require('../model/block-range');
 
-const getLastProcessedBlock = async protocolVersion => {
-  const lastRange = await BlockRange.findOne(
-    protocolVersion === 1
-      ? { protocolVersion: { $in: [protocolVersion, null] } }
-      : { protocolVersion },
-    {},
-    { sort: { toBlock: -1 } },
-  );
+const getLastProcessedBlock = async (eventType, protocolVersion) => {
+  const query = { eventType, protocolVersion };
+  const options = { sort: { toBlock: -1 } };
+  const lastRange = await BlockRange.findOne(query, undefined, options);
 
   if (lastRange === null) {
     return null;

--- a/packages/core/src/events/get-next-block-range.js
+++ b/packages/core/src/events/get-next-block-range.js
@@ -1,17 +1,19 @@
-const { clamp } = require('lodash');
-const { config } = require('@0x-event-extractor/shared');
+const _ = require('lodash');
 
+const getConfigForEventType = require('./get-config-for-event-type');
 const getLastProcessedBlock = require('./get-last-processed-block');
 
-const getNextBlockRange = async ({ currentBlock, protocolVersion }) => {
-  const genesisBlock = config.get(`v${protocolVersion}.genesisBlock`);
-  const maxChunkSize = config.get('maxChunkSize');
-  const minConfirmations = config.get('minConfirmations');
-  const lastProcessedBlock = await getLastProcessedBlock(protocolVersion);
+const getNextBlockRange = async ({
+  currentBlock,
+  eventType,
+  protocolVersion,
+}) => {
+  const config = getConfigForEventType(eventType, protocolVersion);
+  const { maxChunkSize, minConfirmations, startBlock } = config;
+  const lastBlock = await getLastProcessedBlock(eventType, protocolVersion);
   const maxBlock = currentBlock - minConfirmations;
-  const fromBlock =
-    lastProcessedBlock !== null ? lastProcessedBlock + 1 : genesisBlock;
-  const toBlock = clamp(fromBlock + maxChunkSize, 1, maxBlock);
+  const fromBlock = lastBlock === null ? startBlock : lastBlock + 1;
+  const toBlock = _.clamp(fromBlock + maxChunkSize, 1, maxBlock);
 
   // Notify the consumer that there are no blocks to process
   if (toBlock < fromBlock) {

--- a/packages/core/src/jobs/extract-events.js
+++ b/packages/core/src/jobs/extract-events.js
@@ -11,7 +11,7 @@ const withTransaction = require('../util/with-transaction');
 
 const performExtraction = async (currentBlock, extractorConfig) => {
   const {
-    eventType, // TODO: Query by this once we have data in blockranges collection
+    eventType,
     fetchLogEntries,
     getEventData,
     protocolVersion,
@@ -20,7 +20,7 @@ const performExtraction = async (currentBlock, extractorConfig) => {
   // Scope all logging for the job to the specified protocol version and event type
   const logger = getLogger(`extract v${protocolVersion} ${eventType} events`);
 
-  const rangeConfig = { currentBlock, protocolVersion }; // TODO: Also include event type
+  const rangeConfig = { currentBlock, eventType, protocolVersion };
   const nextBlockRange = await getNextBlockRange(rangeConfig);
 
   if (nextBlockRange === null) {

--- a/packages/core/src/model/block-range.js
+++ b/packages/core/src/model/block-range.js
@@ -14,12 +14,6 @@ const schema = Schema({
 // Used for determining last processed block
 schema.index({ protocolVersion: 1, toBlock: -1 });
 
-// Used to enforce consistency in the data
-schema.index(
-  { fromBlock: 1, toBlock: 1, protocolVersion: 1 },
-  { unique: true },
-);
-
 const BlockRange = mongoose.model('BlockRange', schema);
 
 module.exports = BlockRange;


### PR DESCRIPTION
This PR updates event extractor to use event type when determining the next block range to process for a given event extractor. Previously this was modelled around each event extractor belonging to a different protocol version however this won't work when an extractor for TransformedERC20 events is introduced.