### PR TITLE
Introduce extractor for TransformedERC20 events

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -24,6 +24,9 @@ module.exports = {
     logFill: {
       v1: 4145578,
     },
+    transformedErc20: {
+      v3: 10247094,
+    },
   },
   web3: {
     endpoint: process.env.WEB3_ENDPOINT,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     "@0x-event-extractor/fill-extractor-v2": "^1.0.0",
     "@0x-event-extractor/fill-extractor-v3": "^1.0.0",
     "@0x-event-extractor/shared": "^1.0.0",
+    "@0x-event-extractor/transformed-erc20-extractor": "^1.0.0",
     "@bugsnag/js": "6.5.2",
     "bugsnag": "^2.4.3",
     "delay": "^4.3.0",

--- a/packages/core/src/jobs/extract-events.js
+++ b/packages/core/src/jobs/extract-events.js
@@ -1,6 +1,7 @@
 const fillExtractorV1 = require('@0x-event-extractor/fill-extractor-v1');
 const fillExtractorV2 = require('@0x-event-extractor/fill-extractor-v2');
 const fillExtractorV3 = require('@0x-event-extractor/fill-extractor-v3');
+const transformedERC20Extractor = require('@0x-event-extractor/transformed-erc20-extractor');
 
 const { getLogger } = require('../util/logging');
 const BlockRange = require('../model/block-range');
@@ -109,6 +110,7 @@ const extractEvents = async () => {
   await performExtraction(currentBlock, fillExtractorV1);
   await performExtraction(currentBlock, fillExtractorV2);
   await performExtraction(currentBlock, fillExtractorV3);
+  await performExtraction(currentBlock, transformedERC20Extractor);
 
   logger.info('finished event extraction');
 };

--- a/packages/shared/src/web3.js
+++ b/packages/shared/src/web3.js
@@ -4,7 +4,6 @@ const { providerUtils } = require('@0x/utils');
 
 let wrapper;
 let providerEngine;
-
 /**
  * Initializes a web3 provider engine and create a reusable web3 wrapper. The
  * singletons can be accessed via getProviderEngine and getWrapper respectively.
@@ -16,11 +15,57 @@ const configure = ({ endpoint }) => {
   providerEngine = new Web3ProviderEngine();
   wrapper = new Web3Wrapper(providerEngine);
 
+  wrapper.abiDecoder.addABI([
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'taker',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'inputToken',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'outputToken',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'inputTokenAmount',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'outputTokenAmount',
+          type: 'uint256',
+        },
+      ],
+      name: 'TransformedERC20',
+      type: 'event',
+    },
+  ]);
+
   providerEngine.addProvider(new RPCSubprovider(endpoint));
   providerUtils.startProviderEngine(providerEngine);
 };
 
+/**
+ * Get the current global web3 wrapper instance.
+ *
+ * @returns {Web3Wrapper}
+ */
 const getWrapper = () => wrapper;
+
 const getProviderEngine = () => providerEngine;
 
 module.exports = { configure, getProviderEngine, getWrapper };

--- a/packages/transformed-erc20-extractor/package.json
+++ b/packages/transformed-erc20-extractor/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@0x-event-extractor/transformed-erc20-extractor",
+  "description": "Extractor for exchange proxy ERC20 transform events",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "dependencies": {
+    "@0x-event-extractor/shared": "^1.0.0"
+  }
+}

--- a/packages/transformed-erc20-extractor/src/fetch-log-entries.js
+++ b/packages/transformed-erc20-extractor/src/fetch-log-entries.js
@@ -1,0 +1,18 @@
+const { web3 } = require('@0x-event-extractor/shared');
+
+const EXCHANGE_PROXY_ADDRESS = '0xdef1c0ded9bec7f1a1670819833240f027b25eff';
+const TRANSFORMED_ERC20_EVENT_TOPIC =
+  '0x0f6672f78a59ba8e5e5b5d38df3ebc67f3c792e2c9259b8d97d7f00dd78ba1b3';
+
+const fetchEvents = async (fromBlock, toBlock) => {
+  const logs = await web3.getWrapper().getLogsAsync({
+    address: EXCHANGE_PROXY_ADDRESS,
+    fromBlock,
+    toBlock,
+    topics: [TRANSFORMED_ERC20_EVENT_TOPIC],
+  });
+
+  return logs;
+};
+
+module.exports = fetchEvents;

--- a/packages/transformed-erc20-extractor/src/get-event-data.js
+++ b/packages/transformed-erc20-extractor/src/get-event-data.js
@@ -1,0 +1,25 @@
+const { web3 } = require('@0x-event-extractor/shared');
+
+const getEventData = logEntry => {
+  const decoded = web3.getWrapper().abiDecoder.tryToDecodeLogOrNoop(logEntry);
+
+  const {
+    inputToken,
+    inputTokenAmount,
+    outputToken,
+    outputTokenAmount,
+    taker,
+  } = decoded.args;
+
+  const eventData = {
+    inputToken,
+    inputTokenAmount: inputTokenAmount.toString(),
+    outputToken,
+    outputTokenAmount: outputTokenAmount.toString(),
+    taker,
+  };
+
+  return eventData;
+};
+
+module.exports = getEventData;

--- a/packages/transformed-erc20-extractor/src/index.js
+++ b/packages/transformed-erc20-extractor/src/index.js
@@ -1,0 +1,10 @@
+const fetchLogEntries = require('./fetch-log-entries');
+const getEventData = require('./get-event-data');
+
+module.exports = {
+  configure: () => {},
+  eventType: 'TransformedERC20',
+  fetchLogEntries,
+  getEventData,
+  protocolVersion: 3,
+};


### PR DESCRIPTION
This PR introduces an extractor for the TransformedERC20 events which get output by the exchange proxy contract. These will be combined with ERC20BridgeTransfer events in the worker process to identify 0x trades which weren't executed via the traditional fill model.